### PR TITLE
Fix: Set specific Android NDK version to resolve dependency conflict

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.acompanatech"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Updates android/app/build.gradle.kts to set the Android NDK version to "27.0.12077973".

This is necessary because multiple plugins (audioplayers_android, flutter_tts, path_provider_android, shared_preferences_android) require this specific NDK version, and the project was previously configured with an older one, causing a build-time error.